### PR TITLE
Remove fat-finger typing

### DIFF
--- a/src/components/AppNavigation.vue
+++ b/src/components/AppNavigation.vue
@@ -49,7 +49,7 @@ export default {
     },
     methods: {
         logout() {
-            this.$store.dispatch('userSignOut');cd
+            this.$store.dispatch('userSignOut');
         }
     }
 };


### PR DESCRIPTION
Removed mistyped `cd` that is causing syntax error.